### PR TITLE
fix indexing frames in sequence visualization

### DIFF
--- a/joligraf/cli/rl/sequence_pair_img_act.py
+++ b/joligraf/cli/rl/sequence_pair_img_act.py
@@ -29,7 +29,7 @@ def main(data_sequence_folder: str, limit: int, start: int, out: str):
 
     with_slides = {}
     for idx, filepath in enumerate(tqdm(images_filepaths[start:limit])):
-        dataframe = dict([(key, str(value[idx])) for key, value in datasource.items()])
+        dataframe = dict([(key, str(value[start + idx])) for key, value in datasource.items()])
 
         image = hv.RGB.load_image(str(filepath))
         image.opts(title=f"Frame #{idx+1}")


### PR DESCRIPTION
the `enumerate()` function starts indexing from 0. Thus, if we started from a nonzero offset, say `--start=200`, this would pull the observations in `datasource` from frame 0, rather than from frame 200, while correctly displaying the image at frame 200.